### PR TITLE
Install vapoursynth-zip and vapoursynth-julek-plugin

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -182,7 +182,7 @@ echo import site >> python313._pth
 
 :: Download plugins
 .\python.exe .\vsrepo.py update -p  > nul
-.\python.exe .\vsrepo.py install lsmas ffms2 bestsource -p
+.\python.exe .\vsrepo.py install lsmas ffms2 bestsource vszip julek -p
 
 cd ..\
 cd .\svt-av1

--- a/scripts/av1an-batch/param-examples/readme.txt
+++ b/scripts/av1an-batch/param-examples/readme.txt
@@ -1,0 +1,3 @@
+Read this for more information on the Target Quality feature:
+https://rust-av.github.io/Av1an/Cli/target_quality.html
+https://rust-av.github.io/Av1an/Features/TargetQuality.html

--- a/scripts/av1an-batch/param-examples/target-quality-butteraugli.txt
+++ b/scripts/av1an-batch/param-examples/target-quality-butteraugli.txt
@@ -1,0 +1,1 @@
+-e svt-av1 -y --resume --verbose -c mkvmerge -m ffms2 -a "-c:a copy" -v "--keyint 0 --preset 4" --target-metric butteraugli-inf --target-quality 5.4

--- a/scripts/av1an-batch/param-examples/target-quality-ssimu2.txt
+++ b/scripts/av1an-batch/param-examples/target-quality-ssimu2.txt
@@ -1,0 +1,1 @@
+-e svt-av1 -y --resume --verbose -c mkvmerge -m ffms2 -a "-c:a copy" -v "--keyint 0 --preset 4" --target-metric ssimulacra2 --target-quality 80


### PR DESCRIPTION
Adds the capability for quality targeting using SSIMULACRA2 (vapoursynth-zip) and Butteraugli (vapoursynth-julek-plugin)
https://github.com/rust-av/Av1an/commit/c46f7c34837a12b7f9333a57084fd6e244d073a2
SSIMULACRA2 and Butteraugli can be calculated on the GPU (NVIDIA/AMD), if Vship is installed, but I'm unable to test if av1an is going to fallback to the CPU methods if the GPU is unavailable (unsupported GPU), and thus Vship is not installed by default.